### PR TITLE
Add full sensor values and written outdoor temperature support

### DIFF
--- a/pyaprilaire/client.py
+++ b/pyaprilaire/client.py
@@ -88,6 +88,8 @@ class _AprilaireClientProtocol(asyncio.Protocol):
         await self.read_thermostat_status()
         await self.read_control()
         await self.read_sensors()
+        await self.read_sensor_values()
+        await self.read_written_outdoor_temperature()
         await self.read_thermostat_name()
         await self.configure_cos()
         await self.read_dehumidification_setpoint()
@@ -166,9 +168,21 @@ class _AprilaireClientProtocol(asyncio.Protocol):
             asyncio.ensure_future(self.reconnect_action())
 
     async def read_sensors(self):
-        """Send a request for updated sensor data"""
+        """Send a request for updated controlling sensor data"""
         await self._send_packet(
             Packet(Action.READ_REQUEST, FunctionalDomain.SENSORS, 2)
+        )
+
+    async def read_sensor_values(self):
+        """Send a request for the full sensor values array"""
+        await self._send_packet(
+            Packet(Action.READ_REQUEST, FunctionalDomain.SENSORS, 1)
+        )
+
+    async def read_written_outdoor_temperature(self):
+        """Send a request for the written outdoor temperature value"""
+        await self._send_packet(
+            Packet(Action.READ_REQUEST, FunctionalDomain.SENSORS, 4)
         )
 
     async def read_control(self):
@@ -336,7 +350,7 @@ class _AprilaireClientProtocol(asyncio.Protocol):
                     1,  # Thermostat Location & Name
                     0,  # Reserved
                     1,  # Controlling Sensor Values
-                    0,  # Over the air ODT update timeout
+                    1,  # Over the air ODT update timeout
                     1,  # Thermostat Status
                     1,  # IAQ Status
                     1,  # Model & Revision
@@ -370,8 +384,10 @@ class _AprilaireClientProtocol(asyncio.Protocol):
             Packet(Action.READ_REQUEST, FunctionalDomain.CONTROL, 4)
         )
 
-    async def set_written_outdoor_temperature_value(self, value: int):
+    async def set_written_outdoor_temperature_value(self, value: float):
         """Send a request to update the written outdoor temperature value"""
+        value = round(value * 2) / 2
+
         await self._send_packet(
             Packet(
                 Action.WRITE,
@@ -379,11 +395,13 @@ class _AprilaireClientProtocol(asyncio.Protocol):
                 4,
                 data={
                     Attribute.OUTDOOR_SENSOR_STATUS: 0,
-                    Attribute.OUTDOOR_SENSOR: value
-                }
+                    Attribute.OUTDOOR_SENSOR: value,
+                },
             )
         )
-    
+
+        await self.read_written_outdoor_temperature()
+
     async def read_thermostat_iaq_available(self):
         """Send a request to read the thermostat/IAQ available data"""
         await self._send_packet(
@@ -515,8 +533,16 @@ class AprilaireClient(SocketClient):
             return None
 
     async def read_sensors(self):
-        """Send a request for updated sensor data"""
+        """Send a request for updated controlling sensor data"""
         await self.protocol.read_sensors()
+
+    async def read_sensor_values(self):
+        """Send a request for the full sensor values array"""
+        await self.protocol.read_sensor_values()
+
+    async def read_written_outdoor_temperature(self):
+        """Send a request for the written outdoor temperature value"""
+        await self.protocol.read_written_outdoor_temperature()
 
     async def read_control(self):
         """Send a request for updated control data"""
@@ -546,6 +572,10 @@ class AprilaireClient(SocketClient):
         """Send a request to sync data"""
         await self.protocol.sync()
 
+    async def configure_cos(self):
+        """Send a request to configure the COS settings"""
+        await self.protocol.configure_cos()
+
     async def read_mac_address(self):
         """Send a request to read the MAC address"""
         await self.protocol.read_mac_address()
@@ -566,7 +596,7 @@ class AprilaireClient(SocketClient):
     async def set_air_cleaning(self, mode: int, event: int):
         await self.protocol.set_air_cleaning(mode, event)
 
-    async def set_written_outdoor_temperature_value(self, value: int):
+    async def set_written_outdoor_temperature_value(self, value: float):
         """Send a request to update the written outdoor temperature value"""
         await self.protocol.set_written_outdoor_temperature_value(value)
     

--- a/pyaprilaire/mock_server.py
+++ b/pyaprilaire/mock_server.py
@@ -71,6 +71,12 @@ class _AprilaireServerProtocol(asyncio.Protocol):
         self.location = "02134"
         self.mac_address = [1, 2, 3, 4, 5, 6]
 
+        self.written_outdoor_temperature = 25.0
+        self.written_outdoor_temperature_status = 0
+        # Spec: written ODT times out if not refreshed within 10 minutes.
+        self._written_outdoor_timeout_seconds = 600
+        self._written_outdoor_timeout_handle: asyncio.TimerHandle | None = None
+
         self.packet_queue = asyncio.Queue()
 
         self.sequence = 0
@@ -80,6 +86,43 @@ class _AprilaireServerProtocol(asyncio.Protocol):
         self.sequence = (self.sequence + 1) % 128
 
         return self.sequence
+
+    def _cancel_written_outdoor_timeout(self):
+        """Cancel any pending written outdoor temperature timeout"""
+        if self._written_outdoor_timeout_handle is not None:
+            self._written_outdoor_timeout_handle.cancel()
+            self._written_outdoor_timeout_handle = None
+
+    def _schedule_written_outdoor_timeout(self):
+        """Schedule COS status 4 if written outdoor temperature is not refreshed"""
+        self._cancel_written_outdoor_timeout()
+
+        loop = asyncio.get_event_loop()
+        self._written_outdoor_timeout_handle = loop.call_later(
+            self._written_outdoor_timeout_seconds,
+            self._fire_written_outdoor_timeout,
+        )
+
+    def _fire_written_outdoor_timeout(self):
+        """Emit Sensors attribute 4 COS with timed-out status"""
+        self._written_outdoor_timeout_handle = None
+        self.written_outdoor_temperature_status = 4
+
+        if not self.transport:
+            return
+
+        self.packet_queue.put_nowait(
+            Packet(
+                Action.COS,
+                FunctionalDomain.SENSORS,
+                4,
+                sequence=self._get_sequence(),
+                data={
+                    Attribute.OUTDOOR_SENSOR_STATUS: self.written_outdoor_temperature_status,
+                    Attribute.OUTDOOR_SENSOR: self.written_outdoor_temperature,
+                },
+            )
+        )
 
     async def _send_status(self):
         """Send the current status"""
@@ -409,7 +452,34 @@ class _AprilaireServerProtocol(asyncio.Protocol):
                             )
                         )
                 elif packet.functional_domain == FunctionalDomain.SENSORS:
-                    if packet.attribute == 2:
+                    if packet.attribute == 1:
+                        self.packet_queue.put_nowait(
+                            Packet(
+                                Action.READ_RESPONSE,
+                                FunctionalDomain.SENSORS,
+                                1,
+                                sequence=self._get_sequence(),
+                                data={
+                                    Attribute.BUILT_IN_TEMPERATURE_SENSOR_STATUS: 0,
+                                    Attribute.BUILT_IN_TEMPERATURE_SENSOR_VALUE: 25,
+                                    Attribute.WIRED_REMOTE_TEMPERATURE_SENSOR_STATUS: 3,
+                                    Attribute.WIRED_REMOTE_TEMPERATURE_SENSOR_VALUE: 0,
+                                    Attribute.WIRED_OUTDOOR_TEMPERATURE_SENSOR_STATUS: 0,
+                                    Attribute.WIRED_OUTDOOR_TEMPERATURE_SENSOR_VALUE: 20,
+                                    Attribute.BUILT_IN_HUMIDITY_SENSOR_STATUS: 0,
+                                    Attribute.BUILT_IN_HUMIDITY_SENSOR_VALUE: 50,
+                                    Attribute.RAT_SENSOR_STATUS: 0,
+                                    Attribute.RAT_SENSOR_VALUE: 24,
+                                    Attribute.LAT_SENSOR_STATUS: 0,
+                                    Attribute.LAT_SENSOR_VALUE: 18,
+                                    Attribute.WIRELESS_OUTDOOR_TEMPERATURE_SENSOR_STATUS: 3,
+                                    Attribute.WIRELESS_OUTDOOR_TEMPERATURE_SENSOR_VALUE: 0,
+                                    Attribute.WIRELESS_OUTDOOR_HUMIDITY_SENSOR_STATUS: 3,
+                                    Attribute.WIRELESS_OUTDOOR_HUMIDITY_SENSOR_VALUE: 0,
+                                },
+                            )
+                        )
+                    elif packet.attribute == 2:
                         self.packet_queue.put_nowait(
                             Packet(
                                 Action.READ_RESPONSE,
@@ -425,6 +495,19 @@ class _AprilaireServerProtocol(asyncio.Protocol):
                                     Attribute.INDOOR_HUMIDITY_CONTROLLING_SENSOR_VALUE: 50,
                                     Attribute.OUTDOOR_HUMIDITY_CONTROLLING_SENSOR_STATUS: 0,
                                     Attribute.OUTDOOR_HUMIDITY_CONTROLLING_SENSOR_VALUE: 40,
+                                },
+                            )
+                        )
+                    elif packet.attribute == 4:
+                        self.packet_queue.put_nowait(
+                            Packet(
+                                Action.READ_RESPONSE,
+                                FunctionalDomain.SENSORS,
+                                4,
+                                sequence=self._get_sequence(),
+                                data={
+                                    Attribute.OUTDOOR_SENSOR_STATUS: self.written_outdoor_temperature_status,
+                                    Attribute.OUTDOOR_SENSOR: self.written_outdoor_temperature,
                                 },
                             )
                         )
@@ -646,6 +729,27 @@ class _AprilaireServerProtocol(asyncio.Protocol):
                             )
                         )
 
+                elif packet.functional_domain == FunctionalDomain.SENSORS:
+                    if packet.attribute == 4:
+                        if Attribute.OUTDOOR_SENSOR in packet.data:
+                            self.written_outdoor_temperature = packet.data[
+                                Attribute.OUTDOOR_SENSOR
+                            ]
+                            self.written_outdoor_temperature_status = 0
+                            self._schedule_written_outdoor_timeout()
+
+                        self.packet_queue.put_nowait(
+                            Packet(
+                                Action.COS,
+                                FunctionalDomain.SENSORS,
+                                4,
+                                sequence=self._get_sequence(),
+                                data={
+                                    Attribute.OUTDOOR_SENSOR_STATUS: self.written_outdoor_temperature_status,
+                                    Attribute.OUTDOOR_SENSOR: self.written_outdoor_temperature,
+                                },
+                            )
+                        )
                 elif packet.functional_domain == FunctionalDomain.SCHEDULING:
                     if packet.attribute == 4:
                         if Attribute.HOLD in packet.data:
@@ -666,6 +770,7 @@ class _AprilaireServerProtocol(asyncio.Protocol):
 
     def connection_lost(self, exc: Exception | None) -> None:
         _LOGGER.info("Connection lost")
+        self._cancel_written_outdoor_timeout()
         self.transport = None
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -55,7 +55,7 @@ async def test_protocol_update_status(protocol: _AprilaireClientProtocol):
     with patch("asyncio.sleep", new=sleep_mock):
         await protocol._update_status()
 
-    assert protocol.packet_queue.qsize() == 9
+    assert protocol.packet_queue.qsize() == 11
     assert sleep_mock.call_count == 1
 
 
@@ -186,6 +186,24 @@ async def test_protocol_read_sensors(protocol: _AprilaireClientProtocol):
     )
 
 
+async def test_protocol_read_sensor_values(protocol: _AprilaireClientProtocol):
+    await protocol.read_sensor_values()
+
+    assertPacketQueueContains(
+        protocol, Packet(Action.READ_REQUEST, FunctionalDomain.SENSORS, 1)
+    )
+
+
+async def test_protocol_read_written_outdoor_temperature(
+    protocol: _AprilaireClientProtocol,
+):
+    await protocol.read_written_outdoor_temperature()
+
+    assertPacketQueueContains(
+        protocol, Packet(Action.READ_REQUEST, FunctionalDomain.SENSORS, 4)
+    )
+
+
 async def test_protocol_read_control(protocol: _AprilaireClientProtocol):
     await protocol.read_control()
 
@@ -292,7 +310,23 @@ async def test_protocol_sync(protocol: _AprilaireClientProtocol):
 
 
 async def test_protocol_configure_cos(protocol: _AprilaireClientProtocol):
-    pass
+    await protocol.configure_cos()
+
+    queue_items = list(protocol.packet_queue._queue)
+    cos_packets = [
+        packet
+        for packet in queue_items
+        if packet.action == Action.WRITE
+        and packet.functional_domain == FunctionalDomain.STATUS
+        and packet.attribute == 1
+    ]
+
+    assert len(cos_packets) == 1
+    raw_data = cos_packets[0].raw_data
+    assert raw_data is not None
+    assert len(raw_data) == 29
+    assert raw_data[22] == 1  # Controlling Sensor Values
+    assert raw_data[23] == 1  # Over the air ODT update timeout
 
 
 async def test_protocol_read_mac_address(protocol: _AprilaireClientProtocol):
@@ -429,6 +463,26 @@ async def test_client_read_sensors(
 
     assertPacketQueueContains(
         protocol, Packet(Action.READ_REQUEST, FunctionalDomain.SENSORS, 2)
+    )
+
+
+async def test_client_read_sensor_values(
+    client: AprilaireClient, protocol: _AprilaireClientProtocol
+):
+    await client.read_sensor_values()
+
+    assertPacketQueueContains(
+        protocol, Packet(Action.READ_REQUEST, FunctionalDomain.SENSORS, 1)
+    )
+
+
+async def test_client_read_written_outdoor_temperature(
+    client: AprilaireClient, protocol: _AprilaireClientProtocol
+):
+    await client.read_written_outdoor_temperature()
+
+    assertPacketQueueContains(
+        protocol, Packet(Action.READ_REQUEST, FunctionalDomain.SENSORS, 4)
     )
 
 
@@ -626,7 +680,23 @@ async def test_client_sync(client: AprilaireClient, protocol: _AprilaireClientPr
 async def test_client_configure_cos(
     client: AprilaireClient, protocol: _AprilaireClientProtocol
 ):
-    pass
+    await client.configure_cos()
+
+    queue_items = list(protocol.packet_queue._queue)
+    cos_packets = [
+        packet
+        for packet in queue_items
+        if packet.action == Action.WRITE
+        and packet.functional_domain == FunctionalDomain.STATUS
+        and packet.attribute == 1
+    ]
+
+    assert len(cos_packets) == 1
+    raw_data = cos_packets[0].raw_data
+    assert raw_data is not None
+    assert len(raw_data) == 29
+    assert raw_data[22] == 1  # Controlling Sensor Values
+    assert raw_data[23] == 1  # Over the air ODT update timeout
 
 
 async def test_client_read_mac_address(
@@ -686,9 +756,56 @@ async def test_client_set_written_outdoor_temperature_value(
             4,
             data={
                 Attribute.OUTDOOR_SENSOR_STATUS: 0,
-                Attribute.OUTDOOR_SENSOR: 10
-            }
-        )
+                Attribute.OUTDOOR_SENSOR: 10,
+            },
+        ),
+    )
+    assertPacketQueueContains(
+        protocol, Packet(Action.READ_REQUEST, FunctionalDomain.SENSORS, 4)
+    )
+
+
+async def test_client_set_written_outdoor_temperature_value_half_degree(
+    client: AprilaireClient, protocol: _AprilaireClientProtocol
+):
+    await client.set_written_outdoor_temperature_value(21.5)
+
+    assertPacketQueueContains(
+        protocol,
+        Packet(
+            Action.WRITE,
+            FunctionalDomain.SENSORS,
+            4,
+            data={
+                Attribute.OUTDOOR_SENSOR_STATUS: 0,
+                Attribute.OUTDOOR_SENSOR: 21.5,
+            },
+        ),
+    )
+    assertPacketQueueContains(
+        protocol, Packet(Action.READ_REQUEST, FunctionalDomain.SENSORS, 4)
+    )
+
+
+async def test_protocol_set_written_outdoor_temperature_value(
+    protocol: _AprilaireClientProtocol,
+):
+    await protocol.set_written_outdoor_temperature_value(21.7)
+
+    assertPacketQueueContains(
+        protocol,
+        Packet(
+            Action.WRITE,
+            FunctionalDomain.SENSORS,
+            4,
+            data={
+                Attribute.OUTDOOR_SENSOR_STATUS: 0,
+                Attribute.OUTDOOR_SENSOR: 21.5,
+            },
+        ),
+    )
+    assertPacketQueueContains(
+        protocol, Packet(Action.READ_REQUEST, FunctionalDomain.SENSORS, 4)
     )
 
 async def test_client_read_thermostat_iaq_available(

--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -179,6 +179,60 @@ def test_scheduling_4_parse():
     }
 
 
+def test_sensor_1_parse():
+    packets: list[Packet] = list(
+        Packet.parse(
+            [
+                1,
+                1,
+                0,
+                19,
+                3,
+                5,
+                1,
+                0,
+                21,
+                0,
+                20,
+                0,
+                10,
+                0,
+                45,
+                0,
+                22,
+                0,
+                82,
+                3,
+                0,
+                3,
+                0,
+                145,
+            ]
+        )
+    )
+
+    packet = packets[0]
+
+    assert packet.data == {
+        Attribute.BUILT_IN_TEMPERATURE_SENSOR_STATUS: 0,
+        Attribute.BUILT_IN_TEMPERATURE_SENSOR_VALUE: 21.0,
+        Attribute.WIRED_REMOTE_TEMPERATURE_SENSOR_STATUS: 0,
+        Attribute.WIRED_REMOTE_TEMPERATURE_SENSOR_VALUE: 20.0,
+        Attribute.WIRED_OUTDOOR_TEMPERATURE_SENSOR_STATUS: 0,
+        Attribute.WIRED_OUTDOOR_TEMPERATURE_SENSOR_VALUE: 10.0,
+        Attribute.BUILT_IN_HUMIDITY_SENSOR_STATUS: 0,
+        Attribute.BUILT_IN_HUMIDITY_SENSOR_VALUE: 45,
+        Attribute.RAT_SENSOR_STATUS: 0,
+        Attribute.RAT_SENSOR_VALUE: 22.0,
+        Attribute.LAT_SENSOR_STATUS: 0,
+        Attribute.LAT_SENSOR_VALUE: 18.5,
+        Attribute.WIRELESS_OUTDOOR_TEMPERATURE_SENSOR_STATUS: 3,
+        Attribute.WIRELESS_OUTDOOR_TEMPERATURE_SENSOR_VALUE: 0.0,
+        Attribute.WIRELESS_OUTDOOR_HUMIDITY_SENSOR_STATUS: 3,
+        Attribute.WIRELESS_OUTDOOR_HUMIDITY_SENSOR_VALUE: 0,
+    }
+
+
 def test_sensor_2_parse():
     packets: list[Packet] = list(
         Packet.parse([1, 1, 0, 11, 3, 5, 2, 1, 10, 2, 20, 3, 50, 4, 60, 12])
@@ -195,6 +249,19 @@ def test_sensor_2_parse():
         Attribute.INDOOR_HUMIDITY_CONTROLLING_SENSOR_VALUE: 50,
         Attribute.OUTDOOR_HUMIDITY_CONTROLLING_SENSOR_STATUS: 4,
         Attribute.OUTDOOR_HUMIDITY_CONTROLLING_SENSOR_VALUE: 60,
+    }
+
+
+def test_sensor_4_parse():
+    packets: list[Packet] = list(
+        Packet.parse([1, 1, 0, 5, 3, 5, 4, 0, 85, 181])
+    )
+
+    packet = packets[0]
+
+    assert packet.data == {
+        Attribute.OUTDOOR_SENSOR_STATUS: 0,
+        Attribute.OUTDOOR_SENSOR: 21.5,
     }
 
 
@@ -408,6 +475,63 @@ def test_scheduling_4_serialize():
     assert serialized == bytes([1, 1, 0, 13, 3, 3, 4, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 55])
 
 
+def test_sensor_1_serialize():
+    serialized = Packet(
+        Action.READ_RESPONSE,
+        FunctionalDomain.SENSORS,
+        1,
+        1,
+        1,
+        data={
+            Attribute.BUILT_IN_TEMPERATURE_SENSOR_STATUS: 0,
+            Attribute.BUILT_IN_TEMPERATURE_SENSOR_VALUE: 21.0,
+            Attribute.WIRED_REMOTE_TEMPERATURE_SENSOR_STATUS: 0,
+            Attribute.WIRED_REMOTE_TEMPERATURE_SENSOR_VALUE: 20.0,
+            Attribute.WIRED_OUTDOOR_TEMPERATURE_SENSOR_STATUS: 0,
+            Attribute.WIRED_OUTDOOR_TEMPERATURE_SENSOR_VALUE: 10.0,
+            Attribute.BUILT_IN_HUMIDITY_SENSOR_STATUS: 0,
+            Attribute.BUILT_IN_HUMIDITY_SENSOR_VALUE: 45,
+            Attribute.RAT_SENSOR_STATUS: 0,
+            Attribute.RAT_SENSOR_VALUE: 22.0,
+            Attribute.LAT_SENSOR_STATUS: 0,
+            Attribute.LAT_SENSOR_VALUE: 18.5,
+            Attribute.WIRELESS_OUTDOOR_TEMPERATURE_SENSOR_STATUS: 3,
+            Attribute.WIRELESS_OUTDOOR_TEMPERATURE_SENSOR_VALUE: 0.0,
+            Attribute.WIRELESS_OUTDOOR_HUMIDITY_SENSOR_STATUS: 3,
+            Attribute.WIRELESS_OUTDOOR_HUMIDITY_SENSOR_VALUE: 0,
+        },
+    ).serialize()
+
+    assert serialized == bytes(
+        [
+            1,
+            1,
+            0,
+            19,
+            3,
+            5,
+            1,
+            0,
+            21,
+            0,
+            20,
+            0,
+            10,
+            0,
+            45,
+            0,
+            22,
+            0,
+            82,
+            3,
+            0,
+            3,
+            0,
+            145,
+        ]
+    )
+
+
 def test_sensor_2_serialize():
     serialized = Packet(
         Action.READ_RESPONSE,
@@ -428,6 +552,22 @@ def test_sensor_2_serialize():
     ).serialize()
 
     assert serialized == bytes([1, 1, 0, 11, 3, 5, 2, 1, 10, 2, 20, 3, 50, 4, 60, 12])
+
+
+def test_sensor_4_serialize():
+    serialized = Packet(
+        Action.WRITE,
+        FunctionalDomain.SENSORS,
+        4,
+        1,
+        1,
+        data={
+            Attribute.OUTDOOR_SENSOR_STATUS: 0,
+            Attribute.OUTDOOR_SENSOR: 21.5,
+        },
+    ).serialize()
+
+    assert serialized == bytes([1, 1, 0, 5, 1, 5, 4, 0, 85, 34])
 
 
 def test_identification_2_serialize():


### PR DESCRIPTION
## Summary

Exposes the full Aprilaire Sensors domain suite that was already mapped in `packet.py` but never requested, and completes the client path for written outdoor temperature (attribute 4).

### Sensors attribute 1 — full sensor values
- New `read_sensor_values()` API (protocol + public client)
- Requested on connect via `_update_status`
- Decodes and delivers existing attribute keys:
  - built-in temperature / humidity
  - wired remote temperature
  - wired outdoor temperature
  - **RAT** / **LAT**
  - wireless outdoor temperature / humidity
- Attribute 1 is **not** COS-capable (protocol); consumers must re-call `read_sensor_values()` for live updates after connect
- `read_sensors()` remains attribute 2 (controlling sensors) only

### Sensors attribute 4 — written outdoor temperature
- New `read_written_outdoor_temperature()` API
- Read on connect so timeout status is observed after reconnect
- `set_written_outdoor_temperature_value`:
  - still writes Sensors/4 with status `0` (protocol requirement)
  - accepts half-degree °C (`float`, rounded to 0.5)
  - re-reads attribute 4 after write (same pattern as humidification/dehumidification setpoints)
- COS subscription index 23 enabled (“Over the air ODT update timeout”)
- Public `configure_cos()` wrapper added for completeness

### Mock server
- Handles Sensors attribute 1 read (synthetic full array including RAT/LAT)
- Handles Sensors attribute 4 read/write
- After outdoor write, schedules a 10-minute timeout; on expiry emits Sensors/4 COS with status `4` (Timed Out)

### Tests
- Packet parse/serialize for Sensors attributes 1 and 4
- Client/protocol queue tests for new reads and outdoor write (including half-degree and post-write re-read)
- `configure_cos` asserts ODT timeout byte is enabled
- Connect bootstrap queue size updated for the extra reads

## Protocol notes

| Attribute | Access | COS | Notes |
|----------:|--------|:---:|-------|
| 1 Sensor Values | R | No | 16 status/value bytes; explicit ReadRequest only |
| 2 Controlling Sensors | R | Yes | Unchanged |
| 4 Written Outdoor Temperature | R/W | Timeout only | Write status must be 0; refresh more often than every 10 minutes |

## Test plan

- [x] `python -m pytest tests/ -q` (all tests green)
- [x] Against mock server: connect, confirm callback includes `rat_sensor_*` / `lat_sensor_*` after Sensors/1
- [x] Against mock server: `set_written_outdoor_temperature_value(21.5)`, confirm write + re-read
- [x] Optional hardware: Automation outdoor mode, write outdoor temp, confirm device accepts packed °C
- [x] Optional: confirm ODT timeout COS after 10 minutes without refresh (mock timer path)