### PR TITLE
Add weekly Friday dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` to enable automated dependency updates
- Configure `pip` and `github-actions` ecosystems to check weekly on Fridays

## Test plan
- N/A (configuration-only change; Dependabot will pick up the schedule automatically once merged)