### PR TITLE
Bump pip-tools from 6.12.2 to 7.6.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,11 +36,9 @@ packaging==26.3
     #   black
     #   build
     #   pytest
-pathlib2==2.3.7.post1
-    # via bumpver
 pathspec==1.1.1
     # via black
-pip-tools==6.12.2
+pip-tools==7.6.1
     # via pyaprilaire (pyproject.toml)
 platformdirs==3.0.0
     # via black
@@ -49,7 +47,9 @@ pluggy==1.6.0
 pygments==2.20.0
     # via pytest
 pyproject-hooks==1.0.0
-    # via build
+    # via
+    #   build
+    #   pip-tools
 pytest==9.1.1
     # via
     #   pytest-asyncio
@@ -58,8 +58,6 @@ pytest-asyncio==0.21.0
     # via pyaprilaire (pyproject.toml)
 pytest-cov==4.0.0
     # via pyaprilaire (pyproject.toml)
-six==1.17.0
-    # via pathlib2
 toml==0.10.2
     # via bumpver
 tomli==2.0.1
@@ -67,8 +65,13 @@ tomli==2.0.1
     #   black
     #   build
     #   coverage
+    #   pip-tools
     #   pyproject-hooks
     #   pytest
+typing-extensions==4.16.0
+    # via
+    #   exceptiongroup
+    #   pip-tools
 wheel==0.38.4
     # via pip-tools
 


### PR DESCRIPTION
## Summary
- Bumps `pip-tools` dev dependency from 6.12.2 to 7.6.1
- Regenerated `requirements.txt` via `pip-compile --extra=dev pyproject.toml` (Python 3.10) using `--upgrade-package pip-tools` so only pip-tools and its own transitive requirements moved; all other pins are untouched
- Picks up `typing-extensions==4.16.0` as a new transitive dependency of pip-tools, and adds `pip-tools` as an additional "via" reference for `pyproject-hooks` and `tomli` (their pinned versions are unchanged)

## Test plan
- [x] `pip install -r requirements.txt` succeeds in a clean Python 3.10 venv
- [x] `pip-compile --version` reports 7.6.1