### PR TITLE
Replace black/isort with ruff for linting and formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          pip install ruff
       - name: Lint with ruff
         run: |
           ruff check .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: Run tests
+name: CI
 
 on:
   push:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install ruff
+      - name: Lint with ruff
+        run: |
+          ruff check .
+          ruff format --check .
       - name: Test with coverage/pytest
         run: |
           pytest -v --cov=pyaprilaire/ --cov-report=xml --pdb tests/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: local
+    hooks:
+      - id: ruff-check
+        name: ruff check
+        entry: ruff check --fix
+        language: system
+        types: [python]
+      - id: ruff-format
+        name: ruff format
+        entry: ruff format
+        language: system
+        types: [python]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ In order to connect to the thermostat, you will need to enable automation mode. 
 
 # Development
 
+## Linting
+
+This project uses [ruff](https://docs.astral.sh/ruff/) for linting and formatting. After installing the `dev` extra (`pip install -e .[dev]`), enable the pre-commit hooks with:
+
+```
+pre-commit install
+```
+
+This will automatically lint and format staged Python files on each commit. You can also run it manually against the whole repo with `pre-commit run --all-files`.
+
 ## Mock server
 
 During development, it is necessary to connect to a thermostat, but this can be problematic as a thermostat only allows a single connection at a time. There is a mock server that can be run to expose a local server for development that emulates a thermostat.

--- a/pyaprilaire/client.py
+++ b/pyaprilaire/client.py
@@ -57,7 +57,7 @@ class _AprilaireClientProtocol(asyncio.Protocol):
             for _ in range(self.packet_queue.qsize()):
                 self.packet_queue.get_nowait()
                 self.packet_queue.task_done()
-        except:  # pylint: disable=bare-except
+        except Exception:
             pass
 
     async def _queue_loop(self, loop_count=None):

--- a/pyaprilaire/const.py
+++ b/pyaprilaire/const.py
@@ -6,7 +6,7 @@ from enum import Enum, IntEnum
 
 try:
     from enum import StrEnum
-except:
+except ImportError:
 
     class StrEnum(str, Enum):
         pass

--- a/pyaprilaire/packet.py
+++ b/pyaprilaire/packet.py
@@ -297,7 +297,7 @@ class Packet:
             try:
                 action = Action(action)
                 functional_domain = FunctionalDomain(functional_domain)
-            except:
+            except ValueError:
                 data_index += count + 5
                 continue
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-dev = ["bumpver", "pip-tools", "pytest-asyncio", "pytest-cov", "ruff"]
+dev = ["bumpver", "pip-tools", "pre-commit", "pytest-asyncio", "pytest-cov", "ruff"]
 
 [tool.bumpver]
 current_version = "0.9.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-dev = ["black", "bumpver", "isort", "pip-tools", "pytest-asyncio", "pytest-cov"]
+dev = ["bumpver", "pip-tools", "pytest-asyncio", "pytest-cov", "ruff"]
 
 [tool.bumpver]
 current_version = "0.9.1"
@@ -48,5 +48,12 @@ omit = [
     "pyaprilaire/test_connection.py"
 ]
 
-[tool.isort]
-profile = "black" 
+[tool.ruff]
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+ignore = ["E501"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["pyaprilaire"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,15 +4,14 @@
 #
 #    pip-compile --extra=dev pyproject.toml
 #
-black==23.1.0
-    # via pyaprilaire (pyproject.toml)
+backports-asyncio-runner==1.2.0
+    # via pytest-asyncio
 build==1.5.0
     # via pip-tools
 bumpver==2026.1132
     # via pyaprilaire (pyproject.toml)
 click==8.4.2
     # via
-    #   black
     #   bumpver
     #   pip-tools
 colorama==0.4.6
@@ -25,23 +24,14 @@ exceptiongroup==1.3.1
     # via pytest
 iniconfig==2.3.0
     # via pytest
-isort==8.0.1
-    # via pyaprilaire (pyproject.toml)
 lexid==2021.1006
     # via bumpver
-mypy-extensions==1.0.0
-    # via black
 packaging==26.3
     # via
-    #   black
     #   build
     #   pytest
-pathspec==1.1.1
-    # via black
 pip-tools==7.6.1
     # via pyaprilaire (pyproject.toml)
-platformdirs==3.0.0
-    # via black
 pluggy==1.6.0
     # via pytest
 pygments==2.20.0
@@ -58,11 +48,12 @@ pytest-asyncio==1.4.0
     # via pyaprilaire (pyproject.toml)
 pytest-cov==4.0.0
     # via pyaprilaire (pyproject.toml)
+ruff==0.16.3
+    # via pyaprilaire (pyproject.toml)
 toml==0.10.2
     # via bumpver
-tomli==2.0.1
+tomli==2.4.1
     # via
-    #   black
     #   build
     #   coverage
     #   pip-tools
@@ -72,6 +63,7 @@ typing-extensions==4.16.0
     # via
     #   exceptiongroup
     #   pip-tools
+    #   pytest-asyncio
 wheel==0.38.4
     # via pip-tools
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,8 @@ build==1.5.0
     # via pip-tools
 bumpver==2026.1132
     # via pyaprilaire (pyproject.toml)
+cfgv==3.5.0
+    # via pre-commit
 click==8.4.2
     # via
     #   bumpver
@@ -20,20 +22,34 @@ coverage[toml]==7.15.4
     # via pytest-cov
 crc==7.1.0
     # via pyaprilaire (pyproject.toml)
+distlib==0.4.3
+    # via virtualenv
 exceptiongroup==1.3.1
     # via pytest
+filelock==3.32.3
+    # via
+    #   python-discovery
+    #   virtualenv
+identify==2.6.19
+    # via pre-commit
 iniconfig==2.3.0
     # via pytest
 lexid==2021.1006
     # via bumpver
+nodeenv==1.10.0
+    # via pre-commit
 packaging==26.3
     # via
     #   build
     #   pytest
 pip-tools==7.6.1
     # via pyaprilaire (pyproject.toml)
+platformdirs==4.11.2
+    # via virtualenv
 pluggy==1.6.0
     # via pytest
+pre-commit==4.6.2
+    # via pyaprilaire (pyproject.toml)
 pygments==2.20.0
     # via pytest
 pyproject-hooks==1.0.0
@@ -48,6 +64,10 @@ pytest-asyncio==1.4.0
     # via pyaprilaire (pyproject.toml)
 pytest-cov==4.0.0
     # via pyaprilaire (pyproject.toml)
+python-discovery==1.5.2
+    # via virtualenv
+pyyaml==6.0.3
+    # via pre-commit
 ruff==0.16.3
     # via pyaprilaire (pyproject.toml)
 toml==0.10.2
@@ -64,6 +84,9 @@ typing-extensions==4.16.0
     #   exceptiongroup
     #   pip-tools
     #   pytest-asyncio
+    #   virtualenv
+virtualenv==21.7.4
+    # via pre-commit
 wheel==0.38.4
     # via pip-tools
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -175,7 +175,7 @@ async def test_protocol_send_packet(protocol: _AprilaireClientProtocol):
 def assertPacketQueueContains(protocol: _AprilaireClientProtocol, packet: Packet):
     queue_items = list(protocol.packet_queue._queue)
 
-    assert any(qp == packet for qp in queue_items) == True
+    assert any(qp == packet for qp in queue_items)
 
 
 async def test_protocol_read_sensors(protocol: _AprilaireClientProtocol):
@@ -416,12 +416,6 @@ def test_client_state_changed(
     }
 
 
-def assertPacketQueueContains(protocol: _AprilaireClientProtocol, packet: Packet):
-    queue_items = list(protocol.packet_queue._queue)
-
-    assert any(qp == packet for qp in queue_items) == True
-
-
 async def test_client_read_sensors(
     client: AprilaireClient, protocol: _AprilaireClientProtocol
 ):
@@ -644,21 +638,6 @@ async def test_client_read_mac_address(
     )
 
 
-async def test_client_read_thermostat_status(
-    client: AprilaireClient, protocol: _AprilaireClientProtocol
-):
-    await client.read_thermostat_status()
-
-    assertPacketQueueContains(
-        protocol,
-        Packet(
-            Action.READ_REQUEST,
-            FunctionalDomain.CONTROL,
-            7,
-        ),
-    )
-
-
 async def test_client_read_thermostat_name(
     client: AprilaireClient, protocol: _AprilaireClientProtocol
 ):
@@ -728,7 +707,7 @@ async def test_client_wait_for_response_success(client: AprilaireClient):
             FunctionalDomain.CONTROL, 1, 1
         )
 
-    assert wait_for_response_result == True
+    assert wait_for_response_result
 
 
 async def test_client_wait_for_response_timeout(client: AprilaireClient):
@@ -739,7 +718,7 @@ async def test_client_wait_for_response_timeout(client: AprilaireClient):
             FunctionalDomain.CONTROL, 1, 1
         )
 
-    assert wait_for_response_result == None
+    assert wait_for_response_result is None
 
 
 async def test_client_reconnect_with_delay(client: AprilaireClient):

--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -21,7 +21,7 @@ def test_unmapped():
 
 
 def test_packet_empty_parse():
-    packets = list(Packet.parse(bytes()))
+    packets = list(Packet.parse(b""))
 
     assert len(packets) == 0
 
@@ -310,7 +310,7 @@ def test_decode_humidity_nonzero():
 def test_decode_humidity_negative():
     humidity = Packet._decode_humidity(-50)
 
-    assert humidity == None
+    assert humidity is None
 
 
 def test_encode_temperature():
@@ -349,18 +349,6 @@ def test_serialize_raw():
     ).serialize()
 
     assert serialized == bytes([1, 1, 0, 6, 2, 2, 1, 1, 2, 3, 133])
-
-
-def test_serialize_single_packet_no_data():
-    serialized = Packet(
-        Action.READ_REQUEST,
-        FunctionalDomain.CONTROL,
-        1,
-        1,
-        1,
-    ).serialize()
-
-    assert serialized == bytes([1, 1, 0, 3, 2, 2, 1, 70])
 
 
 def test_serialize_single_packet_no_data():

--- a/tests/test_socket_client.py
+++ b/tests/test_socket_client.py
@@ -107,9 +107,12 @@ async def test_auto_reconnect_loop_cancelled(client: SocketClient):
 
     wait_for_mock = AsyncMock(side_effect=asyncio.exceptions.CancelledError)
 
-    with patch(
-        "pyaprilaire.socket_client.SocketClient._reconnect", new=_reconnect_nowait
-    ), patch("asyncio.wait_for", new=wait_for_mock):
+    with (
+        patch(
+            "pyaprilaire.socket_client.SocketClient._reconnect", new=_reconnect_nowait
+        ),
+        patch("asyncio.wait_for", new=wait_for_mock),
+    ):
         await client.start_listen()
         await client._auto_reconnect_loop()
 


### PR DESCRIPTION
Ruff subsumes both black (formatting) and isort (import sorting) in a
single, much faster tool, and adds pyflakes/pycodestyle/pyupgrade/
bugbear rule coverage that surfaced a few real bugs: two pairs of
duplicate test function names that silently shadowed the intended
tests, and three bare `except:` clauses tightened to the specific
exceptions they were actually guarding against.

CI now runs `ruff check` and `ruff format --check` alongside pytest.