### PR TITLE
feat: add conventional commits enforcement and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## Summary
+
+<!-- What does this PR do, and why? -->
+
+## Type of change
+
+<!-- Delete the ones that don't apply -->
+
+- feat: New feature
+- fix: Bug fix
+- docs: Documentation only
+- refactor: Code change that neither fixes a bug nor adds a feature
+- test: Adding or correcting tests
+- chore: Tooling, CI, or other maintenance
+
+## Testing
+
+<!-- How was this verified? e.g. `pytest`, manual testing against a thermostat/mock server -->
+
+## Checklist
+
+- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: add support for X`)
+- [ ] Commits follow Conventional Commits (see [CONTRIBUTING.md](../CONTRIBUTING.md))
+- [ ] Tests added/updated as needed
+- [ ] `ruff check` and `ruff format --check` pass

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,16 @@
+name: PR title lint
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   lint-pr-title:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,9 @@
 repos:
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v4.4.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
   - repo: local
     hooks:
       - id: ruff-check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Repository conventions
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for full details.
+
+- Commit messages and pull request titles must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) (e.g. `fix: reconnect socket after COS packet timeout`, `feat(mock_server): support custom response delay`).
+- When opening a pull request, fill in the [PR template](.github/pull_request_template.md) rather than leaving its sections blank or deleting them.
+- Run `ruff check` and `ruff format --check` before committing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,3 @@
 # Repository conventions
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for full details.
-
-- Commit messages and pull request titles must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) (e.g. `fix: reconnect socket after COS packet timeout`, `feat(mock_server): support custom response delay`).
-- When opening a pull request, fill in the [PR template](.github/pull_request_template.md) rather than leaving its sections blank or deleting them.
-- Run `ruff check` and `ruff format --check` before committing.
+See [AGENTS.md](AGENTS.md) (and [CONTRIBUTING.md](CONTRIBUTING.md)) for commit message, pull request, and linting conventions that apply to all agents working in this repo.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# Repository conventions
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for full details.
+
+- Commit messages and pull request titles must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) (e.g. `fix: reconnect socket after COS packet timeout`, `feat(mock_server): support custom response delay`).
+- When opening a pull request, fill in the [PR template](.github/pull_request_template.md) rather than leaving its sections blank or deleting them.
+- Run `ruff check` and `ruff format --check` before committing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing
 
+> AI agents working in this repo: see [AGENTS.md](AGENTS.md) for a quick summary of these conventions.
+
 ## Commit messages and PR titles
 
 This project follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). This applies to both individual commit messages and pull request titles, and applies equally to human contributors and AI agents.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing
+
+## Commit messages and PR titles
+
+This project follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). This applies to both individual commit messages and pull request titles, and applies equally to human contributors and AI agents.
+
+Format:
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+Common types:
+
+- `feat`: a new feature
+- `fix`: a bug fix
+- `docs`: documentation only changes
+- `refactor`: a code change that neither fixes a bug nor adds a feature
+- `test`: adding or correcting tests
+- `chore`: tooling, CI, dependencies, or other maintenance
+- `perf`: a performance improvement
+
+A breaking change is indicated with a `!` after the type/scope (e.g. `feat!: change socket API`) and/or a `BREAKING CHANGE:` footer.
+
+Examples:
+
+```
+fix: reconnect socket after COS packet timeout
+feat(mock_server): support custom response delay
+docs: document automation mode prerequisite
+```
+
+Commit messages are checked locally via the `conventional-pre-commit` hook (see below), and PR titles are checked in CI.
+
+## Pull requests
+
+Every pull request should use the [pull request template](.github/pull_request_template.md), which is applied automatically when opening a PR. Fill in each section rather than deleting it.
+
+## Linting
+
+This project uses [ruff](https://docs.astral.sh/ruff/) for linting and formatting, and [pre-commit](https://pre-commit.com/) to run checks automatically. After installing the `dev` extra (`pip install -e .[dev]`), enable the hooks with:
+
+```
+pre-commit install --hook-type pre-commit --hook-type commit-msg
+```
+
+This lints/formats staged Python files and validates commit messages against Conventional Commits on each commit. You can also run it manually against the whole repo with `pre-commit run --all-files`.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ pre-commit install
 
 This will automatically lint and format staged Python files on each commit. You can also run it manually against the whole repo with `pre-commit run --all-files`.
 
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for commit message and pull request conventions, including [Conventional Commits](https://www.conventionalcommits.org/).
+
 ## Mock server
 
 During development, it is necessary to connect to a thermostat, but this can be problematic as a thermostat only allows a single connection at a time. There is a mock server that can be run to expose a local server for development that emulates a thermostat.


### PR DESCRIPTION
## Summary

Establishes Conventional Commits as the required style for commit messages and PR titles, and adds a PR template — enforced for both human contributors and AI agents.

- Add `.github/pull_request_template.md` as the default PR description
- Add `CONTRIBUTING.md` documenting Conventional Commits for commit messages and PR titles
- Validate commit messages locally via the `conventional-pre-commit` pre-commit hook
- Validate PR titles in CI via `action-semantic-pull-request` (skipped for Dependabot PRs)
- Add `AGENTS.md` as the canonical, tool-agnostic conventions reference, with `CLAUDE.md` pointing to it
- Link the new conventions from `README.md`

## Type of change

- chore: Tooling, CI, or other maintenance
- docs: Documentation only

## Testing

- Manual review of `.pre-commit-config.yaml` and the new GitHub Actions workflow syntax
- No code paths in `pyaprilaire/` changed; existing `pytest`/`ruff` CI is unaffected

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: add support for X`)
- [x] Commits follow Conventional Commits (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Tests added/updated as needed
- [x] `ruff check` and `ruff format --check` pass
