### PR TITLE
chore: exempt release PRs from PR title lint

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -10,7 +10,9 @@ permissions:
 jobs:
   lint-pr-title:
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]'
+    # Release PRs (release/X.Y.Z -> main) use "release: X.Y.Z" as their title,
+    # which isn't a Conventional Commits type - skip linting for those.
+    if: github.actor != 'dependabot[bot]' && !startsWith(github.head_ref, 'release/')
     steps:
       - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,6 @@
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for full details.
 
-- Commit messages and pull request titles must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) (e.g. `fix: reconnect socket after COS packet timeout`, `feat(mock_server): support custom response delay`).
+- Commit messages and pull request titles must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) (e.g. `fix: reconnect socket after COS packet timeout`, `feat(mock_server): support custom response delay`), except release PRs (`release/X.Y.Z` -> `main`, titled `release: X.Y.Z`), which are exempt from title linting.
 - When opening a pull request, fill in the [PR template](.github/pull_request_template.md) rather than leaving its sections blank or deleting them.
 - Run `ruff check` and `ruff format --check` before committing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,8 @@ docs: document automation mode prerequisite
 
 Commit messages are checked locally via the `conventional-pre-commit` hook (see below), and PR titles are checked in CI.
 
+Release PRs (`release/X.Y.Z` branches targeting `main`, titled `release: X.Y.Z`) are exempt from PR title linting, since `release` isn't a Conventional Commits type.
+
 ## Pull requests
 
 Every pull request should use the [pull request template](.github/pull_request_template.md), which is applied automatically when opening a PR. Fill in each section rather than deleting it.


### PR DESCRIPTION
## Summary

- `release/X.Y.Z` -> `main` PRs are titled `release: X.Y.Z` by the release skill, which isn't a Conventional Commits type and would otherwise fail `pr-title-lint.yml`.
- Adds a `!startsWith(github.head_ref, 'release/')` condition to the lint job, alongside the existing dependabot exception.
- Documents the exception in `CONTRIBUTING.md` and `AGENTS.md`, next to where the Conventional Commits requirement for PR titles is stated.

## Type of change

- chore: Tooling, CI, or other maintenance

## Testing

- No automated tests apply (CI workflow + docs only). Verified the `startsWith(github.head_ref, ...)` expression against GitHub Actions' expression syntax; `github.head_ref` is populated for `pull_request_target` events.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: add support for X`)
- [x] Commits follow Conventional Commits (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] Tests added/updated as needed
- [x] `ruff check` and `ruff format --check` pass (no Python files changed)

---
_Generated by [Claude Code](https://claude.ai/code/session_012UDvFgpv3oiQox1XxZNDwC)_