### PR TITLE
chore: bump crc dependency floor to 7.1.0 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pyaprilaire"
 version = "0.9.1"
 readme = "README.md"
 dependencies = [
-    "crc >= 4"
+    "crc >= 7.1.0"
 ]
 classifiers = [
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
## Summary

`requirements.txt` was already pinned to `crc==7.1.0` (the current latest release on PyPI) via a prior dependabot bump (#50), but `pyproject.toml`'s dependency spec was left at the unbounded floor `crc >= 4`. This raises that floor to `crc >= 7.1.0` so the declared minimum reflects the version actually in use and verified against.

`crc`'s `Calculator`/`Configuration` API used in `pyaprilaire/packet.py` is unchanged across 4.x-7.x, so no source code changes were needed.

## Type of change

- chore: Tooling, CI, or other maintenance

## Testing

- `pip install -e ".[dev]"` with `crc==7.1.0`
- `pytest` — 104 passed
- `ruff check .` and `ruff format --check .` — all clean

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: add support for X`)
- [x] Commits follow Conventional Commits (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Tests added/updated as needed
- [x] `ruff check` and `ruff format --check` pass
